### PR TITLE
Allow for spaces in file path.

### DIFF
--- a/src/iar.js
+++ b/src/iar.js
@@ -32,6 +32,7 @@ class Iar {
         cmd += " --predef_macros"
         var next = 1;
         var arg_fixed = cmd.replace(/\s([a-zA-Z]:[\\\S|*\S].*?)\s-/gm, this.arg_replacer);
+        arg_fixed = arg_fixed.replace(/(.*?)( -\S+)/, "\"$1\"$2") // Fix the lack of quotes on the first filename.
         var regex = /'.*?'|".*?"|\S+/g;
         var args = ['--IDE3', '--NCG'];
         var temp;
@@ -55,7 +56,7 @@ class Iar {
     build_database_single(cmd, inc, def) {
         var args = this.build_database_args(cmd);
         var defs;
-        var tmpfile = os.tmpdir() + "\\" + path.basename(args[2]);
+        var tmpfile = os.tmpdir() + "\\" + path.basename(args[2].replace("\"", ""));
         args.push(tmpfile);
         var spw = ch.spawnSync(this.path + "arm\\bin\\iccarm.exe", args);
         var temp;


### PR DESCRIPTION
Currently, if trying to build with a space in the path, an uncaught exception is thrown and the database build silently fails.

This fix is sort of hacky because file names with a ` -` in the path could still cause the quoting to operate incorrectly but it's the best thing I can think of at the moment. Also, filenames like `Something -Else.txt` are hopefully rare; there should either be spaces around the `-` or not.