### PR TITLE
Add support for cpp projects

### DIFF
--- a/src/iar.js
+++ b/src/iar.js
@@ -154,7 +154,7 @@ class Iar {
         }
 
         //Check compile commands:
-        var icc_regex = new RegExp("^iccarm.exe (.*\\.c) (.*)$", "gm");
+        var icc_regex = new RegExp("^iccarm.exe (.*\\.c|.*\\.cpp) (.*)$", "gm");
         while (temp = icc_regex.exec(build_output)) {
             this.commands.push(temp);
         }
@@ -253,7 +253,7 @@ class Iar {
             while (temp = asm_regex.exec(buffer)) {
                 iar.terminal.appendLine(path.basename(temp[1]));
             }
-            var icc_regex = new RegExp("^iccarm.exe (.*\\.c) (.*)$", "gmi");
+            var icc_regex = new RegExp("^iccarm.exe (.*\\.c|.*\\.cpp) (.*)$", "gmi");
             while (temp = icc_regex.exec(buffer)) {
                 iar.terminal.appendLine(path.basename(temp[1]));
             }


### PR DESCRIPTION
Changed the regex line to add support for parsing *.cpp files as well to support cpp projects.
Otherwise _c_cpp_properties.json_ is not updated with include paths that are relevant to cpp files