### PR TITLE
Fix typo in define (noretrun to noreturn)

### DIFF
--- a/src/iar.js
+++ b/src/iar.js
@@ -80,7 +80,7 @@ class Iar {
             def.push("__little_endian =");
             def.push("__nested =");
             def.push("__no_init =");
-            def.push("__noretrun =");
+            def.push("__noreturn =");
             def.push("__packed =");
             def.push("__pcrel =");
             def.push("__ramfunc =");


### PR DESCRIPTION
Fix a small typo in the automatically generated c_cpp_properties.json file