### PR TITLE
Fixed build_database when config has a space and hyphen

### DIFF
--- a/src/iar.js
+++ b/src/iar.js
@@ -23,16 +23,10 @@ class Iar {
         this.projectname = '';
     }
 
-    arg_replacer(match, p1) {
-        var newstring = ' "' + p1 + '" -';
-        return newstring;
-    }
-
     build_database_args(cmd) {
         cmd += " --predef_macros"
         var next = 1;
-        var arg_fixed = cmd.replace(/\s([a-zA-Z]:[\\\S|*\S].*?)\s-/gm, this.arg_replacer);
-        arg_fixed = arg_fixed.replace(/(.*?)( -\S+)/, "\"$1\"$2") // Fix the lack of quotes on the first filename.
+        var arg_fixed = cmd.replace(/([a-zA-Z]:\\.*?)( -\S|$)/gm, "\"$1\"$2");
         var regex = /'.*?'|".*?"|\S+/g;
         var args = ['--IDE3', '--NCG'];
         var temp;


### PR DESCRIPTION
In cases where config has a space in it (e.g. "Blarg - Debug"), the
output folder would also have a space in it. This broke
build_database_args and build_database_single so iccarm.exe would get
called with malformed arguments:
    [..., "-D", "Whatever I have defined", "-no-cse", ...] instead of
    [..., "-D", "Whatever I have defined", "--no-cse", ...]

The fix was to change the regex used in build_database args to require
a non-space character after the "-" since iccarm doesn't seem to
support "-" as an arg to indicate to read from stdin.

Also, the new regex doesn't require whitespace before the path, so no
fixup is required afterward to handle the first arg.

Additionally, arg_replacer has been replaced with a simple constant
string.